### PR TITLE
Parser class: add assert statement in the else clause of parse() method

### DIFF
--- a/src/main/java/ghbot/parser/Parser.java
+++ b/src/main/java/ghbot/parser/Parser.java
@@ -75,6 +75,9 @@ public class Parser {
         } else if (instr.equalsIgnoreCase(Instruction.FIND.toString())) {
             return new FindExecutor(input[1]);
 
+        } else {
+            // Unreachable code as ui.validateInput already checks for all possible instructions
+            assert false : instr;
         }
         return null;
     }


### PR DESCRIPTION
The parse() method does not ensure whether other inputs are available or not available.

Add assert statement in the else clause.

Adding an assert statement checks that the else clause is unreachable during testing.

Let's
* add a comment to tell where are the inputs being handled
* add an assert statement in the else clause to ensure that the else clause is unreachable during testing